### PR TITLE
fix: bug date when date is 10

### DIFF
--- a/lib/nik_validator.dart
+++ b/lib/nik_validator.dart
@@ -22,7 +22,7 @@ class NIKValidator {
     if (isWoman) {
       date -= 40;
     }
-    return date > 10 ? date.toString() : "0$date";
+    return date > 9 ? date.toString() : "0$date";
   }
 
   ///Get subdistrict split postalcode


### PR DESCRIPTION
jika ada nik yang memiliki tanggal 10 dia akan error saat parsing ke DateTime

karena jika tanggal 10

return date > 10 ? date.toString() : "0$date";

akan mengembalikan 010

saya perbaiki 

return date > 9 ? date.toString() : "0$date";

akan mengembalikan 10