### PR TITLE
fix: bug year when year is 10

### DIFF
--- a/lib/nik_validator.dart
+++ b/lib/nik_validator.dart
@@ -50,8 +50,8 @@ class NIKValidator {
 
   ///Get born year
   String _getBornYear(int nikYear, int currentYear) => nikYear < currentYear
-      ? "20${nikYear > 10 ? nikYear : '0' + nikYear.toString()}"
-      : "19${nikYear > 10 ? nikYear : '0' + nikYear.toString()}";
+      ? "20${nikYear > 9 ? nikYear : '0' + nikYear.toString()}"
+      : "19${nikYear > 9 ? nikYear : '0' + nikYear.toString()}";
 
   ///Get unique code in NIK
   String _getUniqueCode(String nik) => nik.substring(12, 16);


### PR DESCRIPTION
Seperti bug [date 10](https://github.com/yusriltakeuchi/nik_validator/pull/1), bedanya ini di tahun. Kalau tahunnya 10 maka akan jadi `20010`.